### PR TITLE
Fix list-all timeout fixed by unmerged upstream PR

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -27,7 +27,7 @@ function list_all() {
 		else
 			more=false
 		fi
-		additions=$(echo "${res}" | grep -Eo "name.*google-cloud-sdk-[0-9]+\.[0-9]+\.[0-9]+-(linux)-x86_64" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+		additions=$(echo "${res}" | grep -Eo "name.*google-cloud-sdk-[0-9]+\.[0-9]+\.[0-9]+-(linux)-x86_64" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" || true)
 		if [[ -n "${additions}" ]]; then
 			list="${list}\n${additions}"
 		fi


### PR DESCRIPTION
I'm getting the following error message after a long wait:

```
mise WARN  Error getting latest version for gcloud: Failed to run ~/.local/share/mise/plugins/gcloud/bin/list-all: timed out: timed out waiting on channel
```

See upstream issue https://github.com/jthegedus/asdf-gcloud/issues/90 and associated PR fix https://github.com/jthegedus/asdf-gcloud/pull/91 submitted by @sbocinec (thanks, btw!). I'm not sure how to test this fix, so I can't confirm that it works. If testing is required, I'm happy to assist with that.

Thanks in advance!
