### PR TITLE
fix: remove erroneous GET argument from curl call

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -13,7 +13,7 @@ gcs_object_prefix="google-cloud-sdk"
 gcs_object_fields="kind,nextPageToken,items(name)"
 
 function fetch() {
-	curl --silent GET "https://storage.googleapis.com/storage/v1/b/${gcs_bucket_name}/o?pageToken=${1}&prefix=${gcs_object_prefix}&fields=${gcs_object_fields}"
+	curl --silent "https://storage.googleapis.com/storage/v1/b/${gcs_bucket_name}/o?pageToken=${1}&prefix=${gcs_object_prefix}&fields=${gcs_object_fields}"
 }
 
 function list_all() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change removes a stray `GET` argument that was being passed to the curl command in the `list-all` script. At least with curl v8.5.0, it was taking ages from this script to run because curl first trying to hit the address `GET` (equivalent to `curl --silent GET`) and waiting on it for quite some time before actually moving on to hitting the gcs bucket url.

Ultimately, this was causing my terminal to hang for ages when I had `asdf:mise-plugins/mise-gcloud` in my mise tools.

## Motivation and Context

Greatly improves the performance of the mise gcloud plugin.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

```
time mise use asdf:mise-plugins/mise-gcloud
```

## How Has This Been Tested?

I manually tinkered with `$HOME/.local/share/mise/plugins/asdf-mise-plugins-mise-gcloud/bin/list-all` until I noticed the issue and tried the proposed fix.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
